### PR TITLE
Fix joint limit mapping

### DIFF
--- a/Modern Robotics Homework/Course 6/Example Projects/NWU-Modern-Robotics-Capstone-Project-main/NWU-Modern-Robotics-Capstone-Project-main/FeedbackControl.py
+++ b/Modern Robotics Homework/Course 6/Example Projects/NWU-Modern-Robotics-Capstone-Project-main/NWU-Modern-Robotics-Capstone-Project-main/FeedbackControl.py
@@ -65,7 +65,7 @@ def test_joint_limits(position_state, ignore = True):
             test_joints[offset_arm + 2] = False
 
         if theta_arm[3] < -0.05:
-            test_joints[offset_arm + 2] = False
+            test_joints[offset_arm + 3] = False
 
     return test_joints
 


### PR DESCRIPTION
## Summary
- Ensure joint 4 toggles the correct mask column by using `offset_arm + 3` in `test_joint_limits`

## Testing
- `python - <<'PY'
import numpy as np
np.float = float
import sys
sys.path.append('Modern Robotics Homework/Course 6/Example Projects/NWU-Modern-Robotics-Capstone-Project-main/NWU-Modern-Robotics-Capstone-Project-main')
import FeedbackControl as fc

chassis_config=np.zeros(3)
theta_arm=np.array([0,0,-0.1,-0.1,0])
theta_wheels=np.zeros(4)
position_state=(chassis_config,theta_arm,theta_wheels)

test_joints = fc.test_joint_limits(position_state, ignore=False)
print('test_joints:', test_joints)
print('false indices:', np.where(test_joints==False)[0])

J_e = fc.calc_complete_jacobian(position_state,test_joints)
print('Zero columns 5:', np.allclose(J_e[:,5],0))
print('Zero columns 6:', np.allclose(J_e[:,6],0))
PY`
- `python - <<'PY'
import numpy as np
np.float = float
import sys
sys.path.append('Modern Robotics Homework/Course 6/Example Projects/NWU-Modern-Robotics-Capstone-Project-main/NWU-Modern-Robotics-Capstone-Project-main')
import FeedbackControl as fc

chassis_config=np.zeros(3)
theta_wheels=np.zeros(4)

for i in [(-0.1,0), (0,-0.1)]:
    theta_arm=np.array([0,0,i[0],i[1],0])
    position_state=(chassis_config,theta_arm,theta_wheels)
    test_joints=fc.test_joint_limits(position_state, ignore=False)
    print('theta_arm[2]=',i[0],'theta_arm[3]=',i[1])
    print('false indices:', np.where(test_joints==False)[0])
PY`
- `pytest` *(fails: FileNotFoundError: No such file or directory: '../results/tests/trajectory-generator/test1.csv')*

------
https://chatgpt.com/codex/tasks/task_e_68960d1a7b10832081cc67d55e138fbc