### PR TITLE
Avoid side effects in pinv_tol

### DIFF
--- a/Modern Robotics Homework/Course 6/Example Projects/NWU-Modern-Robotics-Capstone-Project-main/NWU-Modern-Robotics-Capstone-Project-main/FeedbackControl.py
+++ b/Modern Robotics Homework/Course 6/Example Projects/NWU-Modern-Robotics-Capstone-Project-main/NWU-Modern-Robotics-Capstone-Project-main/FeedbackControl.py
@@ -41,7 +41,9 @@ pi = m.pi
 np.set_printoptions(suppress=True)
 np.set_printoptions(precision=3)
 
-def pinv_tol(matrix,tol=0.0000001):
+def pinv_tol(matrix, tol=0.0000001):
+
+    matrix = matrix.copy()
 
     matrix[np.where(np.abs(matrix) < tol)] = 0
 


### PR DESCRIPTION
## Summary
- copy matrices before masking in `pinv_tol` to keep inputs unchanged

## Testing
- `python -m py_compile FeedbackControl.py`
- `PYTHONPATH=. python Test_Scripts/FeedbackControl_Testing.py` *(fails: AttributeError: module 'numpy' has no attribute 'float')*


------
https://chatgpt.com/codex/tasks/task_e_68960d1b0dd883209237e2e581b4a459