### PR TITLE
Use conservative joint limit checks

### DIFF
--- a/Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runProject.m
+++ b/Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runProject.m
@@ -99,13 +99,6 @@ Ki = 0.01 * eye(6);    % Integral gain (set to 0 for P control only)
 %% Simulation parameters
 max_speed = 12.3;  % Maximum speed for joints and wheels (rad/s)
 
-% Joint limits (to avoid self-collision and singularities)
-joint_limits = [-pi, pi;      % Joint 1
-                -pi, pi;      % Joint 2  
-                -pi, pi;      % Joint 3
-                -pi, pi;      % Joint 4
-                -pi, pi];     % Joint 5
-
 %% Convert trajectory to SE(3) format
 fprintf('\nRunning feedback control simulation...\n');
 
@@ -144,20 +137,9 @@ for i = 1:N_traj-1
     % Update integral error
     integral_error = integral_error + xerr * dt;
     
-    % Check joint limits
-    arm_angles = config(4:8);
-    violated_joints = [];
-    for j = 1:5
-        if arm_angles(j) <= joint_limits(j,1) + 0.1 || ...
-           arm_angles(j) >= joint_limits(j,2) - 0.1
-            violated_joints = [violated_joints, j];
-        end
-    end
-    
-    % Apply joint limits if necessary
-    if ~isempty(violated_joints)
-        Je = applyJointLimits(Je, violated_joints);
-    end
+    % Check and apply joint limits
+    violated_joints = checkJointLimits(config(4:8));
+    Je = applyJointLimits(Je, violated_joints);
     
     % Calculate joint speeds
     speeds = pinv(Je, 1e-3) * V;

--- a/Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runSimulation.m
+++ b/Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runSimulation.m
@@ -113,13 +113,6 @@ dt = 0.01;              % Timestep (10 ms)
 max_speed = 12.3;       % Maximum joint/wheel speed (rad/s)
 k = 1;                  % Trajectory points per 0.01s
 
-% Joint limits to avoid singularities and self-collision
-joint_limits = [-pi, pi;      % Joint 1
-                -pi, pi;      % Joint 2  
-                -pi, pi;      % Joint 3
-                -pi, pi;      % Joint 4
-                -pi, pi];     % Joint 5
-
 %% Generate reference trajectory
 fprintf('Generating reference trajectory...\n');
 [traj_ref, gripper_ref] = TrajectoryGenerator(Tse_initial, Tsc_initial, ...
@@ -166,19 +159,9 @@ for i = 1:N_traj-1
     % Update integral error
     integral_error = integral_error + Xerr * dt;
     
-    % Check joint limits
-    arm_angles = config(4:8);
-    violated_joints = [];
-    for j = 1:5
-        if arm_angles(j) <= joint_limits(j,1) + 0.1 || ...
-           arm_angles(j) >= joint_limits(j,2) - 0.1
-            violated_joints = [violated_joints, j];
-        end
-    end
-    
-    if ~isempty(violated_joints)
-        Je = applyJointLimits(Je, violated_joints);
-    end
+    % Check and apply joint limits
+    violated_joints = checkJointLimits(config(4:8));
+    Je = applyJointLimits(Je, violated_joints);
     
     % Calculate joint speeds using pseudoinverse
     speeds = pinv(Je, 1e-3) * V;


### PR DESCRIPTION
## Summary
- Remove ad-hoc joint limit matrices from project and simulation runners
- Apply conservative joint limit check before applying joint limit masking

## Testing
- `octave -q --eval "run('Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runProject.m')"` *(fails: 'ScrewTrajectory' undefined)*
- `octave -q --eval "run('Modern Robotics Homework/Course 6/Capstone Project/Capstone_Current/runSimulation.m')"` *(fails: 'ScrewTrajectory' undefined)*


------
https://chatgpt.com/codex/tasks/task_e_689665f9da70832088cc00a6be1cf9ea